### PR TITLE
feat(cd): adding cd for smart contracts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,7 @@ jobs:
     with:
       network: ${{ github.event.inputs.network }}
       environment: ${{ github.event.inputs.environment }}
+      forge-deployment-script: "DeployZenith"
     secrets:
       aws-deployer-role: ${{ secrets.AWS_DEPLOYER_ROLE }}
       holesky-kms-key-id: ${{ secrets.HOLESKY_DEPLOYER_KEY_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,52 @@
+name: Release and Deploy Contract
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      generate-tag:
+        description: 'Generate a new tag'
+        required: true
+        default: 'true'
+      custom-tag: 
+        description: 'Custom tag to be used if generate-tag is false'
+        required: false
+        default: ''
+      network: 
+        description: 'Network to deploy contract to'
+        required: true
+        default: 'holesky'
+        type: choice
+        options:
+          - holesky
+      environment:
+        description: 'Environment to deploy contract to'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+
+permissions:
+  packages: write
+  contents: write
+
+jobs:
+  auto-release:
+    uses: init4tech/actions/.github/workflows/auto-release.yml@main
+    with:
+      generate-tag: true
+      custom-tag: ${{ github.event.inputs.custom-tag }}
+  deploy-contract:
+    uses: init4tech/actions/.github/workflows/solidity-deployment.yml@main
+    needs: auto-release
+    with:
+      network: ${{ github.event.inputs.network }}
+      environment: ${{ github.event.inputs.environment }}
+    secrets:
+      aws-deployer-role: ${{ secrets.AWS_DEPLOYER_ROLE }}
+      holesky-kms-key-id: ${{ secrets.HOLESKY_DEPLOYER_KEY_ID }}
+      holesky-rpc-url: ${{ secrets.HOLESKY_RPC_URL }}
+      etherscan-api-key: ${{ secrets.ETHERSCAN_API_KEY }}


### PR DESCRIPTION
This PR will start creating new releases on pushes to `main`. It will automagically bump the patch semver to the next number and create a release. There is also an option to manually specify the tag you want to create for if/when we want to make new major/minor releases. 

TODO in later pr:
Add a step to update the release notes with the deployed contract addresses