### PR TITLE
feat(cd): support for updating the release notes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,8 +48,8 @@ jobs:
     with:
       network: holesky
       environment: dev
-      forge-deployment-script: DeployZenith
-      deployed-contract: Zenith.s.sol
+      forge-deployment-contract: DeployZenith
+      forge-deployment-script-file: Zenith.s.sol
       forge-deployment-signature: "run()"
       chain-id: 17000
     secrets:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
       environment: dev
       forge-deployment-script: DeployZenith
       deployed-contract: Zenith.s.sol
-      chain-id: ${{ vars.CHAIN_ID }}
+      chain-id: 17000
     secrets:
       aws-deployer-role: ${{ secrets.AWS_DEPLOYER_ROLE }}
       holesky-kms-key-id: ${{ secrets.HOLESKY_DEPLOYER_KEY_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
   workflow_dispatch:
     inputs:
       generate-tag:
@@ -48,7 +50,7 @@ jobs:
       environment: dev
       forge-deployment-script: DeployZenith
       deployed-contract: Zenith.s.sol
-      forge-deployment-signature: run()
+      forge-deployment-signature: "run()"
       chain-id: 17000
     secrets:
       aws-deployer-role: ${{ secrets.AWS_DEPLOYER_ROLE }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,13 +41,14 @@ jobs:
     uses: init4tech/actions/.github/workflows/solidity-deployment.yml@main
     needs: auto-release
     permissions:
-      contents: read
+      contents: write
       id-token: write
     with:
       network: holesky
       environment: dev
       forge-deployment-script: DeployZenith
       deployed-contract: Zenith.s.sol
+      forge-deployment-signature: run()
       chain-id: 17000
     secrets:
       aws-deployer-role: ${{ secrets.AWS_DEPLOYER_ROLE }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,8 @@ jobs:
       network: holesky
       environment: dev
       forge-deployment-script: DeployZenith
+      deployed-contract: Zenith.s.sol
+      chain-id: ${{ vars.CHAIN_ID }}
     secrets:
       aws-deployer-role: ${{ secrets.AWS_DEPLOYER_ROLE }}
       holesky-kms-key-id: ${{ secrets.HOLESKY_DEPLOYER_KEY_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+    paths:
+    - 'src/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'src/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR will add support for the new env vars in the `solidity-deployment.yaml` reuseable workflow. When changes are pushed to main that include specifically changes to files in the `src/**` directory it will create a new patch release, deploy the contracts to holesky, and update the release notes to include the new contract address and a link to holesky etherscan.  