### PR TITLE
refactor: update chainid and block numbers type to uint64

### DIFF
--- a/script/Zenith.s.sol
+++ b/script/Zenith.s.sol
@@ -14,7 +14,7 @@ contract ZenithScript is Script {
     // deploy:
     // forge script ZenithScript --sig "deploy(uint256,address,address[],address,address)" --rpc-url $RPC_URL --etherscan-api-key $ETHERSCAN_API_KEY --private-key $PRIVATE_KEY --broadcast --verify $ROLLUP_CHAIN_ID $WITHDRAWAL_ADMIN_ADDRESS $INITIAL_ENTER_TOKENS_ARRAY $SEQUENCER_AND_GAS_ADMIN_ADDRESS $PERMIT_2
     function deploy(
-        uint256 defaultRollupChainId,
+        uint64 defaultRollupChainId,
         address withdrawalAdmin,
         address[] memory initialEnterTokens,
         address sequencerAndGasAdmin,

--- a/src/Transact.sol
+++ b/src/Transact.sol
@@ -22,7 +22,7 @@ contract Transactor {
 
     /// @notice The total gas used by `transact` so far in this block.
     /// rollupChainId => block number => `transasct` gasLimit used so far.
-    mapping(uint64 rollupChainId => mapping(uint256 blockNumber => uint256 transasct)) public transactGasUsed;
+    mapping(uint64 rollupChainId => mapping(uint64 blockNumber => uint256 transasct)) public transactGasUsed;
 
     /// @notice Emitted to send a special transaction to the rollup.
     event Transact(
@@ -119,9 +119,9 @@ contract Transactor {
         if (gas > perTransactGasLimit) revert PerTransactGasLimit();
 
         // ensure global transact gas limit is respected
-        uint256 gasUsed = transactGasUsed[rollupChainId][block.number];
+        uint256 gasUsed = transactGasUsed[rollupChainId][uint64(block.number)];
         if (gasUsed + gas > perBlockGasLimit) revert PerBlockTransactGasLimit();
-        transactGasUsed[rollupChainId][block.number] = gasUsed + gas;
+        transactGasUsed[rollupChainId][uint64(block.number)] = gasUsed + gas;
 
         // emit Transact event
         emit Transact(uint64(rollupChainId), msg.sender, to, data, value, gas, maxFeePerGas);

--- a/src/Transact.sol
+++ b/src/Transact.sol
@@ -6,7 +6,7 @@ import {Passage} from "./passage/Passage.sol";
 /// @notice A contract deployed to Host chain that enables transactions from L1 to be sent on an L2.
 contract Transactor {
     /// @notice The chainId of rollup that Ether will be sent to by default when entering the rollup via fallback() or receive().
-    uint256 public immutable defaultRollupChainId;
+    uint64 public immutable defaultRollupChainId;
 
     /// @notice The address that is allowed to configure `transact` gas limits.
     address public immutable gasAdmin;
@@ -22,11 +22,11 @@ contract Transactor {
 
     /// @notice The total gas used by `transact` so far in this block.
     /// rollupChainId => block number => `transasct` gasLimit used so far.
-    mapping(uint256 => mapping(uint256 => uint256)) public transactGasUsed;
+    mapping(uint64 rollupChainId => mapping(uint256 blockNumber => uint256 transasct)) public transactGasUsed;
 
     /// @notice Emitted to send a special transaction to the rollup.
     event Transact(
-        uint256 indexed rollupChainId,
+        uint64 indexed rollupChainId,
         address indexed sender,
         address indexed to,
         bytes data,
@@ -50,7 +50,7 @@ contract Transactor {
     /// @param _defaultRollupChainId - the chainId of the rollup that Ether will be sent to by default
     ///                                when entering the rollup via fallback() or receive() fns.
     constructor(
-        uint256 _defaultRollupChainId,
+        uint64 _defaultRollupChainId,
         address _gasAdmin,
         Passage _passage,
         uint256 _perBlockGasLimit,
@@ -72,7 +72,7 @@ contract Transactor {
     /// @dev Transaction is processed after normal rollup block execution.
     /// @dev See `enterTransact` for docs.
     function transact(
-        uint256 rollupChainId,
+        uint64 rollupChainId,
         address to,
         bytes calldata data,
         uint256 value,
@@ -102,7 +102,7 @@ contract Transactor {
     /// @param maxFeePerGas - The maximum fee per gas for the transaction (per EIP-1559).
     /// @custom:emits Transact indicating the transaction to mine on the rollup.
     function enterTransact(
-        uint256 rollupChainId,
+        uint64 rollupChainId,
         address etherRecipient,
         address to,
         bytes calldata data,
@@ -124,7 +124,7 @@ contract Transactor {
         transactGasUsed[rollupChainId][block.number] = gasUsed + gas;
 
         // emit Transact event
-        emit Transact(rollupChainId, msg.sender, to, data, value, gas, maxFeePerGas);
+        emit Transact(uint64(rollupChainId), msg.sender, to, data, value, gas, maxFeePerGas);
     }
 
     /// @notice Helper to configure gas limits on deploy & via admin function

--- a/src/Zenith.sol
+++ b/src/Zenith.sol
@@ -17,7 +17,7 @@ contract Zenith {
     ///                        this allows the sequencer to sign over finalized set of transactions,
     ///                        without the Zenith contract needing to interact with raw transaction data (which may be provided via blobs or calldata).
     struct BlockHeader {
-        uint256 rollupChainId;
+        uint64 rollupChainId;
         uint256 hostBlockNumber;
         uint256 gasLimit;
         address rewardAddress;
@@ -26,7 +26,7 @@ contract Zenith {
 
     /// @notice The host block number that a block was last submitted at for a given rollup chainId.
     /// rollupChainId => host blockNumber that block was last submitted at
-    mapping(uint256 => uint256) public lastSubmittedAtBlock;
+    mapping(uint64 => uint256) public lastSubmittedAtBlock;
 
     /// @notice Registry of permissioned sequencers.
     /// address => TRUE if it's a permissioned sequencer
@@ -55,7 +55,7 @@ contract Zenith {
     /// @dev including blockDataHash allows the sequencer to sign over finalized block data, without needing to calldatacopy the `blockData` param.
     event BlockSubmitted(
         address indexed sequencer,
-        uint256 indexed rollupChainId,
+        uint64 indexed rollupChainId,
         uint256 gasLimit,
         address rewardAddress,
         bytes32 blockDataHash

--- a/src/Zenith.sol
+++ b/src/Zenith.sol
@@ -6,7 +6,7 @@ contract Zenith {
     address public immutable sequencerAdmin;
 
     /// @notice The block number at which the Zenith contract was deployed.
-    uint256 public deployBlockNumber;
+    uint64 public deployBlockNumber;
 
     /// @notice Block header information for the rollup block, signed by the sequencer.
     /// @param rollupChainId - the chainId of the rollup chain. Any chainId is accepted by the contract.
@@ -18,7 +18,7 @@ contract Zenith {
     ///                        without the Zenith contract needing to interact with raw transaction data (which may be provided via blobs or calldata).
     struct BlockHeader {
         uint64 rollupChainId;
-        uint256 hostBlockNumber;
+        uint64 hostBlockNumber;
         uint256 gasLimit;
         address rewardAddress;
         bytes32 blockDataHash;
@@ -26,7 +26,7 @@ contract Zenith {
 
     /// @notice The host block number that a block was last submitted at for a given rollup chainId.
     /// rollupChainId => host blockNumber that block was last submitted at
-    mapping(uint64 => uint256) public lastSubmittedAtBlock;
+    mapping(uint64 rollupChainId => uint64 hostBlockNumber) public lastSubmittedAtBlock;
 
     /// @notice Registry of permissioned sequencers.
     /// address => TRUE if it's a permissioned sequencer
@@ -66,7 +66,7 @@ contract Zenith {
 
     constructor(address _sequencerAdmin) {
         sequencerAdmin = _sequencerAdmin;
-        deployBlockNumber = block.number;
+        deployBlockNumber = uint64(block.number);
     }
 
     /// @notice Add a sequencer to the permissioned sequencer list.
@@ -115,7 +115,7 @@ contract Zenith {
 
         // assert this is the first rollup block submitted for this host block
         if (lastSubmittedAtBlock[header.rollupChainId] == block.number) revert OneRollupBlockPerHostBlock();
-        lastSubmittedAtBlock[header.rollupChainId] = block.number;
+        lastSubmittedAtBlock[header.rollupChainId] = uint64(block.number);
 
         // emit event
         emit BlockSubmitted(

--- a/src/orders/IOrders.sol
+++ b/src/orders/IOrders.sol
@@ -23,6 +23,6 @@ interface IOrders {
         address recipient;
         /// @dev When emitted on the origin chain, the destination chain for the Output.
         ///      When emitted on the destination chain, the origin chain for the Order containing the Output.
-        uint32 chainId;
+        uint64 chainId;
     }
 }

--- a/src/passage/Passage.sol
+++ b/src/passage/Passage.sol
@@ -8,7 +8,7 @@ import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 /// @notice A contract deployed to Host chain that allows tokens to enter the rollup.
 contract Passage is PassagePermit2 {
     /// @notice The chainId of rollup that Ether will be sent to by default when entering the rollup via fallback() or receive().
-    uint256 public immutable defaultRollupChainId;
+    uint64 public immutable defaultRollupChainId;
 
     /// @notice The address that is allowed to withdraw funds from the contract.
     address public immutable tokenAdmin;
@@ -26,7 +26,7 @@ contract Passage is PassagePermit2 {
     /// @param rollupChainId - The chainId of the destination rollup.
     /// @param rollupRecipient - The recipient of Ether on the rollup.
     /// @param amount - The amount of Ether entering the rollup.
-    event Enter(uint256 indexed rollupChainId, address indexed rollupRecipient, uint256 amount);
+    event Enter(uint64 indexed rollupChainId, address indexed rollupRecipient, uint256 amount);
 
     /// @notice Emitted when ERC20 tokens enter the rollup.
     /// @param rollupChainId - The chainId of the destination rollup.
@@ -34,7 +34,7 @@ contract Passage is PassagePermit2 {
     /// @param token - The host chain address of the token entering the rollup.
     /// @param amount - The amount of tokens entering the rollup.
     event EnterToken(
-        uint256 indexed rollupChainId, address indexed rollupRecipient, address indexed token, uint256 amount
+        uint64 indexed rollupChainId, address indexed rollupRecipient, address indexed token, uint256 amount
     );
 
     /// @notice Emitted when the admin withdraws tokens from the contract.
@@ -46,7 +46,7 @@ contract Passage is PassagePermit2 {
     /// @param _defaultRollupChainId - the chainId of the rollup that Ether will be sent to by default
     ///                                when entering the rollup via fallback() or receive() fns.
     constructor(
-        uint256 _defaultRollupChainId,
+        uint64 _defaultRollupChainId,
         address _tokenAdmin,
         address[] memory initialEnterTokens,
         address _permit2
@@ -72,7 +72,7 @@ contract Passage is PassagePermit2 {
     /// @param rollupChainId - The rollup chain to enter.
     /// @param rollupRecipient - The recipient of the Ether on the rollup.
     /// @custom:emits Enter indicating the amount of Ether to mint on the rollup & its recipient.
-    function enter(uint256 rollupChainId, address rollupRecipient) public payable {
+    function enter(uint64 rollupChainId, address rollupRecipient) public payable {
         if (msg.value == 0) return;
         emit Enter(rollupChainId, rollupRecipient, msg.value);
     }
@@ -88,7 +88,7 @@ contract Passage is PassagePermit2 {
     /// @param rollupRecipient - The recipient of tokens on the rollup.
     /// @param token - The host chain address of the token entering the rollup.
     /// @param amount - The amount of tokens entering the rollup.
-    function enterToken(uint256 rollupChainId, address rollupRecipient, address token, uint256 amount) public {
+    function enterToken(uint64 rollupChainId, address rollupRecipient, address token, uint256 amount) public {
         // transfer tokens to this contract
         IERC20(token).transferFrom(msg.sender, address(this), amount);
         // check and emit
@@ -105,7 +105,7 @@ contract Passage is PassagePermit2 {
     /// @param rollupChainId - The rollup chain to enter.
     /// @param rollupRecipient - The recipient of tokens on the rollup.
     /// @param permit2 - The Permit2 information, including token & amount.
-    function enterTokenPermit2(uint256 rollupChainId, address rollupRecipient, PassagePermit2.Permit2 calldata permit2)
+    function enterTokenPermit2(uint64 rollupChainId, address rollupRecipient, PassagePermit2.Permit2 calldata permit2)
         external
     {
         // transfer tokens to this contract via permit2
@@ -133,7 +133,7 @@ contract Passage is PassagePermit2 {
     }
 
     /// @notice Shared functionality for tokens entering rollup.
-    function _enterToken(uint256 rollupChainId, address rollupRecipient, address token, uint256 amount) internal {
+    function _enterToken(uint64 rollupChainId, address rollupRecipient, address token, uint256 amount) internal {
         if (amount == 0) return;
         if (!canEnter[token]) revert DisallowedEnter(token);
         emit EnterToken(rollupChainId, rollupRecipient, token, amount);

--- a/test/Passage.t.sol
+++ b/test/Passage.t.sol
@@ -14,7 +14,7 @@ contract PassageTest is Test {
     Passage public target;
     address token;
     address newToken;
-    uint256 chainId = 3;
+    uint64 chainId = 3;
     address recipient = address(0x123);
     uint256 amount = 200;
 
@@ -24,14 +24,14 @@ contract PassageTest is Test {
     uint256 gas = 10_000_000;
     uint256 maxFeePerGas = 50;
 
-    event Enter(uint256 indexed rollupChainId, address indexed rollupRecipient, uint256 amount);
+    event Enter(uint64 indexed rollupChainId, address indexed rollupRecipient, uint256 amount);
 
     event EnterToken(
-        uint256 indexed rollupChainId, address indexed rollupRecipient, address indexed token, uint256 amount
+        uint64 indexed rollupChainId, address indexed rollupRecipient, address indexed token, uint256 amount
     );
 
     event Transact(
-        uint256 indexed rollupChainId,
+        uint64 indexed rollupChainId,
         address indexed sender,
         address indexed to,
         bytes data,
@@ -52,7 +52,7 @@ contract PassageTest is Test {
         // deploy target
         address[] memory initialEnterTokens = new address[](1);
         initialEnterTokens[0] = token;
-        target = new Passage(block.chainid + 1, address(this), initialEnterTokens, address(0));
+        target = new Passage(uint64(uint64(block.chainid + 1)), address(this), initialEnterTokens, address(0));
         TestERC20(token).approve(address(target), amount * 10000);
 
         // deploy token two, don't configure
@@ -62,7 +62,7 @@ contract PassageTest is Test {
     }
 
     function test_setUp() public {
-        assertEq(target.defaultRollupChainId(), block.chainid + 1);
+        assertEq(target.defaultRollupChainId(), uint64(block.chainid + 1));
         assertEq(target.tokenAdmin(), address(this));
         assertTrue(target.canEnter(token));
         assertFalse(target.canEnter(newToken));

--- a/test/Permit2Passage.t.sol
+++ b/test/Permit2Passage.t.sol
@@ -34,11 +34,11 @@ contract PassagePermit2Test is SharedPermit2Test {
     // token consts
     address token;
     uint256 amount = 200;
-    uint256 chainId = 3;
+    uint64 chainId = 3;
     address recipient = address(0x123);
 
     event EnterToken(
-        uint256 indexed rollupChainId, address indexed rollupRecipient, address indexed token, uint256 amount
+        uint64 indexed rollupChainId, address indexed rollupRecipient, address indexed token, uint256 amount
     );
 
     function setUp() public {
@@ -57,7 +57,7 @@ contract PassagePermit2Test is SharedPermit2Test {
         _setupSinglePermit(token, amount);
 
         // deploy Passage
-        target = new Passage(block.chainid + 1, address(this), initialEnterTokens, address(permit2Contract));
+        target = new Passage(uint64(block.chainid + 1), address(this), initialEnterTokens, address(permit2Contract));
         vm.label(address(target), "passage");
 
         // construct Enter witness

--- a/test/Transact.t.sol
+++ b/test/Transact.t.sol
@@ -10,7 +10,7 @@ import {Test, console2} from "forge-std/Test.sol";
 contract TransactTest is Test {
     Passage public passage;
     Transactor public target;
-    uint256 chainId = 3;
+    uint64 chainId = 3;
     address recipient = address(0x123);
     uint256 amount = 200;
 
@@ -21,7 +21,7 @@ contract TransactTest is Test {
     uint256 maxFeePerGas = 50;
 
     event Transact(
-        uint256 indexed rollupChainId,
+        uint64 indexed rollupChainId,
         address indexed sender,
         address indexed to,
         bytes data,
@@ -33,16 +33,16 @@ contract TransactTest is Test {
     event GasConfigured(uint256 perBlock, uint256 perTransact);
 
     // Passage event
-    event Enter(uint256 indexed rollupChainId, address indexed rollupRecipient, uint256 amount);
+    event Enter(uint64 indexed rollupChainId, address indexed rollupRecipient, uint256 amount);
 
     function setUp() public {
         // deploy target
-        passage = new Passage(block.chainid + 1, address(this), new address[](0), address(0));
-        target = new Transactor(block.chainid + 1, address(this), passage, gas * 6, gas);
+        passage = new Passage(uint64(block.chainid + 1), address(this), new address[](0), address(0));
+        target = new Transactor(uint64(block.chainid + 1), address(this), passage, gas * 6, gas);
     }
 
     function test_setUp() public {
-        assertEq(target.defaultRollupChainId(), block.chainid + 1);
+        assertEq(target.defaultRollupChainId(), uint64(block.chainid + 1));
         assertEq(target.gasAdmin(), address(this));
         assertEq(address(target.passage()), address(passage));
         assertEq(target.perBlockGasLimit(), gas * 6);

--- a/test/Zenith.t.sol
+++ b/test/Zenith.t.sol
@@ -33,7 +33,7 @@ contract ZenithTest is Test {
 
         // set default block values
         header.rollupChainId = uint64(block.chainid + 1);
-        header.hostBlockNumber = block.number;
+        header.hostBlockNumber = uint64(block.number);
         header.gasLimit = 30_000_000;
         header.rewardAddress = address(this);
         header.blockDataHash = keccak256(blockData);

--- a/test/Zenith.t.sol
+++ b/test/Zenith.t.sol
@@ -19,7 +19,7 @@ contract ZenithTest is Test {
 
     event BlockSubmitted(
         address indexed sequencer,
-        uint256 indexed rollupChainId,
+        uint64 indexed rollupChainId,
         uint256 gasLimit,
         address rewardAddress,
         bytes32 blockDataHash
@@ -32,7 +32,7 @@ contract ZenithTest is Test {
         target.addSequencer(vm.addr(sequencerKey));
 
         // set default block values
-        header.rollupChainId = block.chainid + 1;
+        header.rollupChainId = uint64(block.chainid + 1);
         header.hostBlockNumber = block.number;
         header.gasLimit = 30_000_000;
         header.rewardAddress = address(this);


### PR DESCRIPTION
## Description:
- Refactored block numbers and chainIds to use uint64 rather than uint32 or uint256. 
- Tests passing
- Closes #64 