### PR TITLE
feat: Add Parmigiana testnet support for fuzz tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
     with:
       gas-diff-tolerance: 2 # setting the gas diff tolerance to 2%
       foundry-profile: rollup
-      fork-url: ${{ vars.PARMIGIANA_RU_RPC_URL }}
+      fork-url: ${{ vars.RU_RPC_URL }}
   fork-host:
     uses: init4tech/actions/.github/workflows/solidity-base.yml@main
     with:
       gas-diff-tolerance: 2 # setting the gas diff tolerance to 2%
       foundry-profile: host
-      fork-url: ${{ vars.PARMIGIANA_HOST_RPC_URL }}
+      fork-url: ${{ vars.HOST_RPC_URL }}
 
   # Parmigiana testnet fuzz tests
   parmigiana-fuzz-rollup:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
     with:
       gas-diff-tolerance: 2 # setting the gas diff tolerance to 2%
       foundry-profile: rollup
-      fork-url: ${{ vars.RU_RPC_URL }}
+      fork-url: ${{ vars.PARMIGIANA_RU_RPC_URL }}
   fork-host:
     uses: init4tech/actions/.github/workflows/solidity-base.yml@main
     with:
       gas-diff-tolerance: 2 # setting the gas diff tolerance to 2%
       foundry-profile: host
-      fork-url: ${{ vars.HOST_RPC_URL }}
+      fork-url: ${{ vars.PARMIGIANA_HOST_RPC_URL }}
 
   # Parmigiana testnet fuzz tests
   parmigiana-fuzz-rollup:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,17 @@ jobs:
       foundry-profile: host
       fork-url: ${{ vars.HOST_RPC_URL }}
 
-  # Parmigiana testnet fuzz tests
-  parmigiana-fuzz-rollup:
+  # Fuzz tests against testnet
+  fuzz-rollup:
     uses: init4tech/actions/.github/workflows/solidity-base.yml@main
     with:
       gas-diff-tolerance: 2
       foundry-profile: fuzz-rollup
-      fork-url: ${{ vars.PARMIGIANA_RU_RPC_URL }}
-  parmigiana-fuzz-host:
+      fork-url: ${{ vars.RU_RPC_URL }}
+  fuzz-host:
     uses: init4tech/actions/.github/workflows/solidity-base.yml@main
     with:
       gas-diff-tolerance: 2
       foundry-profile: fuzz-host
-      fork-url: ${{ vars.PARMIGIANA_HOST_RPC_URL }}
+      fork-url: ${{ vars.HOST_RPC_URL }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,17 @@ jobs:
       foundry-profile: host
       fork-url: ${{ vars.HOST_RPC_URL }}
 
+  # Parmigiana testnet fuzz tests
+  parmigiana-fuzz-rollup:
+    uses: init4tech/actions/.github/workflows/solidity-base.yml@main
+    with:
+      gas-diff-tolerance: 2
+      foundry-profile: fuzz-rollup
+      fork-url: ${{ vars.PARMIGIANA_RU_RPC_URL }}
+  parmigiana-fuzz-host:
+    uses: init4tech/actions/.github/workflows/solidity-base.yml@main
+    with:
+      gas-diff-tolerance: 2
+      foundry-profile: fuzz-host
+      fork-url: ${{ vars.PARMIGIANA_HOST_RPC_URL }}
+

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,20 @@
+{
+  "lib/forge-std": {
+    "rev": "8e40513d678f392f398620b3ef2b418648b33e89"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "45558b816d34485fe4b0830d1f5206f241a34b77"
+  },
+  "lib/permit2": {
+    "rev": "cc56ad0f3439c502c246fc5cfcc3db92bb8b7219"
+  },
+  "lib/safe-smart-account": {
+    "rev": "d6b4fca7138b6235bc54744c1f7cc147422b7245"
+  },
+  "lib/simple-erc20": {
+    "rev": "f5c2597ec179ea13e219ccbca415dc59d5a33398"
+  },
+  "lib/stablecoin-evm": {
+    "rev": "f1dfc9eb54aacc6db137470d6ab99b1f8216aaa4"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,4 +10,10 @@ test= "test/rollup"
 [profile.host]
 test= "test/host"
 
+[profile.fuzz-rollup]
+test= "test/fuzz-rollup"
+
+[profile.fuzz-host]
+test= "test/fuzz-host"
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/test/SignetStd.sol
+++ b/test/SignetStd.sol
@@ -9,6 +9,52 @@ import {HostOrders} from "../src/orders/HostOrders.sol";
 import {Passage} from "../src/passage/Passage.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
+/// @title ParmigianaConstants
+/// @author init4
+/// @notice Constants for the Parmigiana testnet.
+/// @dev These constants are used to configure the SignetStd contract in its
+///      constructor, if the chain ID matches the Parmigiana testnet chain ID.
+library ParmigianaConstants {
+    /// @notice The Parmigiana Rollup chain ID.
+    uint32 constant ROLLUP_CHAIN_ID = 88888;
+    /// @notice The Rollup Passage contract for the Parmigiana testnet.
+    RollupPassage constant ROLLUP_PASSAGE = RollupPassage(payable(0x0000000000007369676E65742D70617373616765));
+    /// @notice The Rollup Orders contract for the Parmigiana testnet.
+    RollupOrders constant ROLLUP_ORDERS = RollupOrders(0x000000000000007369676E65742D6f7264657273);
+    /// @notice WETH token address for the Parmigiana testnet.
+    IERC20 constant ROLLUP_WETH = IERC20(0x0000000000000000007369676e65742d77657468);
+    /// @notice WBTC token address for the Parmigiana testnet.
+    IERC20 constant ROLLUP_WBTC = IERC20(0x0000000000000000007369676e65742D77627463);
+    /// @notice WUSD token address for the Parmigiana testnet.
+    IERC20 constant ROLLUP_WUSD = IERC20(0x0000000000000000007369676e65742D77757364);
+
+    /// @notice The Parmigiana host chain ID.
+    uint32 constant HOST_CHAIN_ID = 3151908;
+    /// @notice The Passage contract on the host network.
+    Passage constant HOST_PASSAGE = Passage(payable(0x28524D2a753925Ef000C3f0F811cDf452C6256aF));
+    /// @notice The Orders contract on the host network.
+    HostOrders constant HOST_ORDERS = HostOrders(0x96f44ddc3Bc8892371305531F1a6d8ca2331fE6C);
+    /// @notice The Zenith contract for the Parmigiana testnet.
+    Zenith constant HOST_ZENITH = Zenith(0x143A5BE4E559cA49Dbf0966d4B9C398425C5Fc19);
+    /// @notice The Transactor contract on the host network.
+    Transactor constant HOST_TRANSACTOR = Transactor(0x0B4fc18e78c585687E01c172a1087Ea687943db9);
+    /// @notice USDC token for the Parmigiana testnet host chain.
+    IERC20 constant HOST_USDC = IERC20(0x65Fb255585458De1F9A246b476aa8d5C5516F6fd);
+    /// @notice USDT token for the Parmigiana testnet host chain.
+    IERC20 constant HOST_USDT = IERC20(0xb9Df1b911B6cf6935b2a918Ba03dF2372E94e267);
+    /// @notice WBTC token for the Parmigiana testnet host chain.
+    IERC20 constant HOST_WBTC = IERC20(0xfb29F7d7a4CE607D6038d44150315e5F69BEa08A);
+    /// @notice WETH token for the Parmigiana testnet host chain.
+    IERC20 constant HOST_WETH = IERC20(0xD1278f17e86071f1E658B656084c65b7FD3c90eF);
+
+    /// @notice The token admin address, used for configuring tokens on Passage and for withdrawals.
+    address constant TOKEN_ADMIN = address(0x11Aa4EBFbf7a481617c719a2Df028c9DA1a219aa);
+    /// @notice The gas admin address, used for configuring gas limits on Transactor.
+    address constant GAS_ADMIN = address(0x29403F107781ea45Bf93710abf8df13F67f2008f);
+    /// @notice The sequencer admin address, used for configuring sequencer settings on Zenith.
+    address constant SEQUENCER_ADMIN = address(0x29403F107781ea45Bf93710abf8df13F67f2008f);
+}
+
 /// @title PecorinoConstants
 /// @author init4
 /// @notice Constants for the Pecorino testnet.
@@ -111,28 +157,63 @@ contract SignetStd {
 
     function setupStd() internal virtual {
         // Auto-configure based on the chain ID.
-        if (block.chainid == PecorinoConstants.ROLLUP_CHAIN_ID || block.chainid == PecorinoConstants.HOST_CHAIN_ID) {
-            ROLLUP_CHAIN_ID = PecorinoConstants.ROLLUP_CHAIN_ID;
-            ROLLUP_PASSAGE = PecorinoConstants.ROLLUP_PASSAGE;
-            ROLLUP_ORDERS = PecorinoConstants.ROLLUP_ORDERS;
-            ROLLUP_WETH = PecorinoConstants.ROLLUP_WETH;
-            ROLLUP_WBTC = PecorinoConstants.ROLLUP_WBTC;
-            ROLLUP_WUSD = PecorinoConstants.ROLLUP_WUSD;
-
-            HOST_CHAIN_ID = PecorinoConstants.HOST_CHAIN_ID;
-            HOST_PASSAGE = PecorinoConstants.HOST_PASSAGE;
-            HOST_ORDERS = PecorinoConstants.HOST_ORDERS;
-            HOST_ZENITH = PecorinoConstants.HOST_ZENITH;
-            HOST_TRANSACTOR = PecorinoConstants.HOST_TRANSACTOR;
-            HOST_USDC = PecorinoConstants.HOST_USDC;
-            HOST_USDT = PecorinoConstants.HOST_USDT;
-            HOST_WBTC = PecorinoConstants.HOST_WBTC;
-            HOST_WETH = PecorinoConstants.HOST_WETH;
-            TOKEN_ADMIN = PecorinoConstants.TOKEN_ADMIN;
-            GAS_ADMIN = PecorinoConstants.GAS_ADMIN;
-            SEQUENCER_ADMIN = PecorinoConstants.SEQUENCER_ADMIN;
+        // Parmigiana testnet (rollup chain ID 88888)
+        if (block.chainid == ParmigianaConstants.ROLLUP_CHAIN_ID) {
+            _setupParmigiana();
+        }
+        // Pecorino testnet (rollup chain ID 14174)
+        else if (block.chainid == PecorinoConstants.ROLLUP_CHAIN_ID) {
+            _setupPecorino();
+        }
+        // Host chain ID (3151908) - shared by both testnets, default to Parmigiana
+        else if (block.chainid == ParmigianaConstants.HOST_CHAIN_ID) {
+            _setupParmigiana();
         } else {
             revert("Unsupported chain ID");
         }
+    }
+
+    function _setupParmigiana() internal {
+        ROLLUP_CHAIN_ID = ParmigianaConstants.ROLLUP_CHAIN_ID;
+        ROLLUP_PASSAGE = ParmigianaConstants.ROLLUP_PASSAGE;
+        ROLLUP_ORDERS = ParmigianaConstants.ROLLUP_ORDERS;
+        ROLLUP_WETH = ParmigianaConstants.ROLLUP_WETH;
+        ROLLUP_WBTC = ParmigianaConstants.ROLLUP_WBTC;
+        ROLLUP_WUSD = ParmigianaConstants.ROLLUP_WUSD;
+
+        HOST_CHAIN_ID = ParmigianaConstants.HOST_CHAIN_ID;
+        HOST_PASSAGE = ParmigianaConstants.HOST_PASSAGE;
+        HOST_ORDERS = ParmigianaConstants.HOST_ORDERS;
+        HOST_ZENITH = ParmigianaConstants.HOST_ZENITH;
+        HOST_TRANSACTOR = ParmigianaConstants.HOST_TRANSACTOR;
+        HOST_USDC = ParmigianaConstants.HOST_USDC;
+        HOST_USDT = ParmigianaConstants.HOST_USDT;
+        HOST_WBTC = ParmigianaConstants.HOST_WBTC;
+        HOST_WETH = ParmigianaConstants.HOST_WETH;
+        TOKEN_ADMIN = ParmigianaConstants.TOKEN_ADMIN;
+        GAS_ADMIN = ParmigianaConstants.GAS_ADMIN;
+        SEQUENCER_ADMIN = ParmigianaConstants.SEQUENCER_ADMIN;
+    }
+
+    function _setupPecorino() internal {
+        ROLLUP_CHAIN_ID = PecorinoConstants.ROLLUP_CHAIN_ID;
+        ROLLUP_PASSAGE = PecorinoConstants.ROLLUP_PASSAGE;
+        ROLLUP_ORDERS = PecorinoConstants.ROLLUP_ORDERS;
+        ROLLUP_WETH = PecorinoConstants.ROLLUP_WETH;
+        ROLLUP_WBTC = PecorinoConstants.ROLLUP_WBTC;
+        ROLLUP_WUSD = PecorinoConstants.ROLLUP_WUSD;
+
+        HOST_CHAIN_ID = PecorinoConstants.HOST_CHAIN_ID;
+        HOST_PASSAGE = PecorinoConstants.HOST_PASSAGE;
+        HOST_ORDERS = PecorinoConstants.HOST_ORDERS;
+        HOST_ZENITH = PecorinoConstants.HOST_ZENITH;
+        HOST_TRANSACTOR = PecorinoConstants.HOST_TRANSACTOR;
+        HOST_USDC = PecorinoConstants.HOST_USDC;
+        HOST_USDT = PecorinoConstants.HOST_USDT;
+        HOST_WBTC = PecorinoConstants.HOST_WBTC;
+        HOST_WETH = PecorinoConstants.HOST_WETH;
+        TOKEN_ADMIN = PecorinoConstants.TOKEN_ADMIN;
+        GAS_ADMIN = PecorinoConstants.GAS_ADMIN;
+        SEQUENCER_ADMIN = PecorinoConstants.SEQUENCER_ADMIN;
     }
 }


### PR DESCRIPTION
## Summary

Migrates Solidity fuzz tests to support the Parmigiana testnet.

## Changes

- **SignetStd.sol**: Added `ParmigianaConstants` library with Parmigiana contract addresses (chain ID 88888). Updated `setupStd()` to auto-configure based on detected chain ID.
- **foundry.toml**: Added `fuzz-rollup` and `fuzz-host` profiles for running fuzz tests against specific test directories.
- **CI workflow**: Added `fuzz-rollup` and `fuzz-host` jobs using existing RPC endpoint variables.

## Notes

- Uses existing `RU_RPC_URL` and `HOST_RPC_URL` repository variables (no new config required)
- When running on host chain (3151908), defaults to Parmigiana constants as the current testnet

Closes [ENG-1861](https://linear.app/initiates/issue/ENG-1861/migrate-solidity-fuzz-tests-to-parmigiana)